### PR TITLE
Environment Based Config Path Selection

### DIFF
--- a/src/discord/config.clj
+++ b/src/discord/config.clj
@@ -3,7 +3,8 @@
             [clojure.java.io :as io])
   (:import [java.io IOException]))
 
-(defonce global-bot-settings "data/settings/settings.json")
+(defonce global-bot-settings (or (System/getenv "DISCORD_CONFIG_PATH")
+                                 "data/settings/settings.json"))
 
 ;;; Saving, loading, and checking config files
 (defmulti file-io


### PR DESCRIPTION
Addresses https://github.com/gizmo385/discord.clj/issues/14 . I know there was a comment in there about being open to command-line args, but what do you think of environment based config instead? 