### PR TITLE
Fix reconnect failing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [com.taoensso/timbre "4.10.0"]
                  [org.clojure/data.json "0.2.6"]
                  [overtone/at-at "1.2.0"]
-                 [stylefruits/gniazdo "1.0.0"]]
+                 [stylefruits/gniazdo "1.2.0"]]
   :main ^:skip-aot discord.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/discord/gateway.clj
+++ b/src/discord/gateway.clj
@@ -264,7 +264,6 @@
       :on-close   (fn [status reason]
                     ;; The codes above 1001 denote erroreous closure states
                     ;; https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
-                    (println status reason)
                     (cond
                       (= 1006 status) (do
                                         (timbre/warnf "Socket closed for reason (%d): %s" status reason)

--- a/src/discord/gateway.clj
+++ b/src/discord/gateway.clj
@@ -111,13 +111,14 @@
 
 (defmethod handle-gateway-control-event :invalidate-session
   [discord-event gateway receive-chan]
-  (timbre/infof "(invalidate-session) Event of Type: %s" (message-code->name (:op discord-event)))
+  (timbre/infof "Event of Type: %s" (message-code->name (:op discord-event)))
+  ;; Wait a few seconds then attempt to identify, per Discord docs
   @(future (Thread/sleep 3000) (send-identify gateway)))
 
 (defmethod handle-gateway-control-event :reconnect
   [discord-event gateway receive-chan]
-  (timbre/infof "(reconnect) Event of Type: %s" (message-code->name (:op discord-event)))
-  (ws/close @(:websocket gateway) 999 "reconnect message received"))
+  (timbre/infof "Event of Type: %s" (message-code->name (:op discord-event)))
+  (ws/close @(:websocket gateway) 1000 "Reconnect request"))
 
 (defmethod handle-gateway-control-event :default
   [discord-event gateway receive-chan]
@@ -265,7 +266,7 @@
                     ;; https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
                     (println status reason)
                     (cond
-                      (= 1002 status) (do
+                      (= 1006 status) (do
                                         (timbre/warnf "Socket closed for reason (%d): %s" status reason)
                                         (timbre/warnf "Attempting to reconnect to websocket...")
                                         (reconnect-gateway gateway))


### PR DESCRIPTION
Was seeing a lot of `1006: Disconnected` messages and stopped the bot. Added handlers for `reconnect` and `invalidate-session` and added conditional restarting of gateway websocket on `1006: Disconnected`

Not sure if this is the correct way to handle a disconnect/reconnect, but my bot continues working.